### PR TITLE
fix: sanitize GHA ${{ }} expressions to prevent TS parse errors

### DIFF
--- a/packages/core/src/utils/yaml-extractor.ts
+++ b/packages/core/src/utils/yaml-extractor.ts
@@ -77,12 +77,11 @@ export const extractByYaml = (
   documents: string
 ): { code: string; startOffset: number; endOffset: number }[] => {
   const parser = new Parser();
-  const parsed = parser.parse(documents).next().value as CST.Document;
-
-  // Handle empty or invalid documents
-  if (!parsed || !parsed.value) {
-    return [];
+  for (const token of parser.parse(documents)) {
+    if (token.type === "document") {
+      if (!token.value) return [];
+      return findScriptsCST(token.value);
+    }
   }
-
-  return findScriptsCST(parsed.value);
+  return [];
 };

--- a/packages/core/src/virtualCodes/edge-cases.test.ts
+++ b/packages/core/src/virtualCodes/edge-cases.test.ts
@@ -1,4 +1,5 @@
 import { GitHubScriptVirtualCode } from "./githubScript";
+import { extractByYaml } from "../utils/yaml-extractor";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import * as ts from "typescript";
@@ -10,7 +11,7 @@ const githubRoot = resolve(
   "..",
   "..",
   "sample",
-  ".github"
+  ".github",
 );
 
 test("既存のworkflowファイルが正しく動作する", async () => {
@@ -23,7 +24,7 @@ test("既存のworkflowファイルが正しく動作する", async () => {
   } as ts.IScriptSnapshot;
 
   const virtualCode = new GitHubScriptVirtualCode(snapshot, "yaml");
-  
+
   expect(virtualCode.id).toBe("root");
   expect(virtualCode.embeddedCodes.length).toBeGreaterThan(0);
 });
@@ -31,13 +32,14 @@ test("既存のworkflowファイルが正しく動作する", async () => {
 test("空のworkflowファイルでクラッシュしない", () => {
   const emptyWorkflow = "";
   const snapshot = {
-    getText: (start: number, end: number) => emptyWorkflow.substring(start, end),
+    getText: (start: number, end: number) =>
+      emptyWorkflow.substring(start, end),
     getLength: () => emptyWorkflow.length,
     getChangeRange: () => undefined,
   } as ts.IScriptSnapshot;
 
   const virtualCode = new GitHubScriptVirtualCode(snapshot, "yaml");
-  
+
   expect(virtualCode.id).toBe("root");
   expect(virtualCode.embeddedCodes.length).toBe(0);
 });
@@ -45,13 +47,14 @@ test("空のworkflowファイルでクラッシュしない", () => {
 test("スペースのみのworkflowファイルでクラッシュしない", () => {
   const whitespaceWorkflow = "   \n  \n";
   const snapshot = {
-    getText: (start: number, end: number) => whitespaceWorkflow.substring(start, end),
+    getText: (start: number, end: number) =>
+      whitespaceWorkflow.substring(start, end),
     getLength: () => whitespaceWorkflow.length,
     getChangeRange: () => undefined,
   } as ts.IScriptSnapshot;
 
   const virtualCode = new GitHubScriptVirtualCode(snapshot, "yaml");
-  
+
   expect(virtualCode.id).toBe("root");
   expect(virtualCode.embeddedCodes.length).toBe(0);
 });
@@ -67,7 +70,8 @@ jobs:
       - uses: actions/checkout@v2
 `;
   const snapshot = {
-    getText: (start: number, end: number) => noScriptWorkflow.substring(start, end),
+    getText: (start: number, end: number) =>
+      noScriptWorkflow.substring(start, end),
     getLength: () => noScriptWorkflow.length,
     getChangeRange: () => undefined,
   } as ts.IScriptSnapshot;
@@ -103,8 +107,76 @@ jobs:
   expect(virtualCode.embeddedCodes.length).toBe(1);
   const generated = virtualCode.embeddedCodes[0].snapshot.getText(
     0,
-    virtualCode.embeddedCodes[0].snapshot.getLength()
+    virtualCode.embeddedCodes[0].snapshot.getLength(),
   );
   expect(generated).not.toContain("${{");
   expect(generated).toContain("undefined");
 });
+
+test("複数の ${{ }} expressions が全て sanitize される", () => {
+  const workflow = `
+name: Test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const msg = \`Hello \${{ inputs.name }}, you are \${{ github.actor }}\`;
+            core.info(msg);
+`;
+  const snapshot = {
+    getText: (start: number, end: number) => workflow.substring(start, end),
+    getLength: () => workflow.length,
+    getChangeRange: () => undefined,
+  } as ts.IScriptSnapshot;
+
+  const virtualCode = new GitHubScriptVirtualCode(snapshot, "yaml");
+
+  expect(virtualCode.embeddedCodes.length).toBe(1);
+  const generated = virtualCode.embeddedCodes[0].snapshot.getText(
+    0,
+    virtualCode.embeddedCodes[0].snapshot.getLength(),
+  );
+  expect(generated).not.toContain("${{");
+  // ${{ inputs.name }} と ${{ github.actor }} の2つが置換される
+  expect(generated.match(/undefined/g)?.length).toBe(2);
+});
+
+test.fails(
+  "${{ }} を含むスクリプトのソースマッピングが元のYAMLの全範囲をカバーする",
+  () => {
+    const workflow = `
+name: Test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const msg = \`Hello \${{ inputs.name }}\`;
+            core.info(msg);
+`;
+    const snapshot = {
+      getText: (start: number, end: number) => workflow.substring(start, end),
+      getLength: () => workflow.length,
+      getChangeRange: () => undefined,
+    } as ts.IScriptSnapshot;
+
+    const scripts = extractByYaml(workflow);
+    expect(scripts.length).toBe(1);
+    const originalCodeLength = scripts[0].code.length;
+
+    const virtualCode = new GitHubScriptVirtualCode(snapshot, "yaml");
+    const mapping = virtualCode.embeddedCodes[0].mappings[0];
+
+    // ソース側のマッピング長はYAMLの元のコード長と一致しなければならない。
+    // sanitize 後の短い長さ（sanitizedCode.length）になっていると、
+    // ${{ }} 以降のコードのソース位置が正確に参照できなくなる。
+    expect(mapping.lengths[0]).toBe(originalCodeLength);
+  },
+);

--- a/packages/core/src/virtualCodes/edge-cases.test.ts
+++ b/packages/core/src/virtualCodes/edge-cases.test.ts
@@ -73,7 +73,38 @@ jobs:
   } as ts.IScriptSnapshot;
 
   const virtualCode = new GitHubScriptVirtualCode(snapshot, "yaml");
-  
+
   expect(virtualCode.id).toBe("root");
   expect(virtualCode.embeddedCodes.length).toBe(0);
+});
+
+test("${{ }} expressions in template literals are sanitized to prevent TS parse errors", () => {
+  const workflow = `
+name: Test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const msg = \`Hello \${{ inputs.name }}\`;
+            core.info(msg);
+`;
+  const snapshot = {
+    getText: (start: number, end: number) => workflow.substring(start, end),
+    getLength: () => workflow.length,
+    getChangeRange: () => undefined,
+  } as ts.IScriptSnapshot;
+
+  const virtualCode = new GitHubScriptVirtualCode(snapshot, "yaml");
+
+  expect(virtualCode.embeddedCodes.length).toBe(1);
+  const generated = virtualCode.embeddedCodes[0].snapshot.getText(
+    0,
+    virtualCode.embeddedCodes[0].snapshot.getLength()
+  );
+  expect(generated).not.toContain("${{");
+  expect(generated).toContain("undefined");
 });

--- a/packages/core/src/virtualCodes/edge-cases.test.ts
+++ b/packages/core/src/virtualCodes/edge-cases.test.ts
@@ -145,9 +145,7 @@ jobs:
   expect(generated.match(/undefined/g)?.length).toBe(2);
 });
 
-test.fails(
-  "${{ }} を含むスクリプトのソースマッピングが元のYAMLの全範囲をカバーする",
-  () => {
+test("${{ }} を含むスクリプトのソースマッピングが元のYAMLの全範囲をカバーする", () => {
     const workflow = `
 name: Test
 on: push
@@ -169,14 +167,19 @@ jobs:
 
     const scripts = extractByYaml(workflow);
     expect(scripts.length).toBe(1);
-    const originalCodeLength = scripts[0].code.length;
+    const originalScript = scripts[0];
 
     const virtualCode = new GitHubScriptVirtualCode(snapshot, "yaml");
     const mapping = virtualCode.embeddedCodes[0].mappings[0];
 
-    // ソース側のマッピング長はYAMLの元のコード長と一致しなければならない。
-    // sanitize 後の短い長さ（sanitizedCode.length）になっていると、
-    // ${{ }} 以降のコードのソース位置が正確に参照できなくなる。
-    expect(mapping.lengths[0]).toBe(originalCodeLength);
-  },
-);
+    // GHA式をまたいで複数セグメントに分割されているはず
+    expect(mapping.sourceOffsets.length).toBeGreaterThan(1);
+
+    // 全セグメントの末尾がYAMLの元コードの末尾に一致するか確認
+    const lastIdx = mapping.sourceOffsets.length - 1;
+    const lastSourceEnd =
+      mapping.sourceOffsets[lastIdx] + mapping.lengths[lastIdx];
+    expect(lastSourceEnd).toBe(
+      originalScript.startOffset + originalScript.code.length
+    );
+});

--- a/packages/core/src/virtualCodes/githubScript.test.ts
+++ b/packages/core/src/virtualCodes/githubScript.test.ts
@@ -59,6 +59,9 @@ t(
         // length: 110,
         sourceOffsets: 589,
       },
+      {
+        sourceOffsets: 802,
+      },
     ]);
   }
 );

--- a/packages/core/src/virtualCodes/githubScript.ts
+++ b/packages/core/src/virtualCodes/githubScript.ts
@@ -39,8 +39,43 @@ function* getGitHubScriptEmbeddedCodes(
     const post = `}`;
     // Replace ${{ }} expressions with `undefined` so the TS language server
     // does not try to parse them as template literal interpolations.
-    const sanitizedCode = script.code.replace(/\$\{\{[^}]*\}\}/g, "undefined");
+    const ghaPattern = /\$\{\{[^}]*\}\}/g;
+    const sanitizedCode = script.code.replace(ghaPattern, "undefined");
     const text = pre + sanitizedCode + post;
+
+    // Build segmented mappings that skip over GHA expressions.
+    // A single flat mapping would offset everything after the first GHA expression
+    // because `undefined` (9 chars) is shorter than `${{ ... }}`.
+    const sourceOffsets: number[] = [];
+    const generatedOffsets: number[] = [];
+    const lengths: number[] = [];
+    let lastSourceEnd = 0;
+    let genPos = 0;
+    let match: RegExpExecArray | null;
+    ghaPattern.lastIndex = 0;
+    while ((match = ghaPattern.exec(script.code)) !== null) {
+      const segLen = match.index - lastSourceEnd;
+      if (segLen > 0) {
+        sourceOffsets.push(script.startOffset + lastSourceEnd);
+        generatedOffsets.push(pre.length + genPos);
+        lengths.push(segLen);
+        genPos += segLen;
+      }
+      genPos += "undefined".length;
+      lastSourceEnd = match.index + match[0].length;
+    }
+    const remainingLen = script.code.length - lastSourceEnd;
+    if (remainingLen > 0) {
+      sourceOffsets.push(script.startOffset + lastSourceEnd);
+      generatedOffsets.push(pre.length + genPos);
+      lengths.push(remainingLen);
+    }
+    if (sourceOffsets.length === 0) {
+      sourceOffsets.push(script.startOffset);
+      generatedOffsets.push(pre.length);
+      lengths.push(script.code.length);
+    }
+
     yield {
       id: "script_" + i,
       languageId: "javascript", // github-scripts not supporting TypeScript
@@ -51,9 +86,9 @@ function* getGitHubScriptEmbeddedCodes(
       },
       mappings: [
         {
-          sourceOffsets: [script.startOffset],
-          generatedOffsets: [pre.length],
-          lengths: [sanitizedCode.length],
+          sourceOffsets,
+          generatedOffsets,
+          lengths,
           data: {
             completion: true,
             format: true,

--- a/packages/core/src/virtualCodes/githubScript.ts
+++ b/packages/core/src/virtualCodes/githubScript.ts
@@ -37,7 +37,10 @@ function* getGitHubScriptEmbeddedCodes(
     const script = scripts[i];
     const pre = `export default async ({ context, core, exec, github, glob, io, require }: import('@types/github-script').AsyncFunctionArguments) => {`;
     const post = `}`;
-    const text = pre + script.code + post;
+    // Replace ${{ }} expressions with `undefined` so the TS language server
+    // does not try to parse them as template literal interpolations.
+    const sanitizedCode = script.code.replace(/\$\{\{[^}]*\}\}/g, "undefined");
+    const text = pre + sanitizedCode + post;
     yield {
       id: "script_" + i,
       languageId: "javascript", // github-scripts not supporting TypeScript
@@ -50,7 +53,7 @@ function* getGitHubScriptEmbeddedCodes(
         {
           sourceOffsets: [script.startOffset],
           generatedOffsets: [pre.length],
-          lengths: [script.code.length],
+          lengths: [sanitizedCode.length],
           data: {
             completion: true,
             format: true,

--- a/sample/.github/workflows/sample.yml
+++ b/sample/.github/workflows/sample.yml
@@ -25,4 +25,10 @@ jobs:
               // show errors, ')' expected
               foo.bar(;
           #```
-  
+      - uses: actions/github-script@v7
+        with:
+          script: | #```typescript
+              const msg = `Hello ${{ inputs.name }}, you are ${{ github.actor }}`;
+              core.debug('fromJSON: ${{ fromJSON(inputs.value) }}');
+              const obj = ${{ fromJSON(inputs.value) }};
+          #```


### PR DESCRIPTION
## Problem

When a `script:` block contains GitHub Actions expressions inside JS template literals, the TS language server produces a false parse error:

```yaml
- uses: actions/github-script@v9
  with:
    script: |
      const msg = `Hello ${{ inputs.name }}`;
```

Error: `',' expected.ts(1005)`

The TS parser sees `${` as the start of a template interpolation, then tries to parse `{ inputs.name }` as an expression and fails because `inputs.name` is not a valid shorthand property.

This is a false positive — GHA substitutes `${{ }}` expressions before the script executes, so the JS never sees them.

## Fix

Sanitize `${{ ... }}` occurrences to `undefined` in the virtual code text before it reaches the TS language server. Semantically correct: from the TS perspective these are runtime string values, so `undefined` is an appropriate placeholder.

Adds a test in `edge-cases.test.ts` covering this scenario.